### PR TITLE
Introduce IServiceCollection.AddEventHandlers extension method 

### DIFF
--- a/src/M.EventBrokerSlim/DependencyInjection/EventBrokerBuilder.cs
+++ b/src/M.EventBrokerSlim/DependencyInjection/EventBrokerBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace M.EventBrokerSlim.DependencyInjection;
+
+/// <summary>
+/// Registers EventBroker and configures event broker behavior, optionally registers event handlers in DI container.
+/// </summary>
+public class EventBrokerBuilder : EventHandlerRegistryBuilder
+{
+    internal EventBrokerBuilder(IServiceCollection services) : base(services)
+    {
+    }
+
+    internal int _maxConcurrentHandlers = 2;
+
+    internal bool _disableMissingHandlerWarningLog;
+
+    /// <summary>
+    /// Sets the maximum number of event handlers to run at the same time.
+    /// </summary>
+    /// <param name="maxConcurrentHandlers">Maximum number of event handlers to run at the same time. Default is 2.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Throws when <paramref name="maxConcurrentHandlers"/> is less than 1.</exception>
+    public EventBrokerBuilder WithMaxConcurrentHandlers(int maxConcurrentHandlers)
+    {
+        if (maxConcurrentHandlers <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxConcurrentHandlers), "MaxConcurrentHandlers should be greater than zero");
+        }
+
+        _maxConcurrentHandlers = maxConcurrentHandlers;
+        return this;
+    }
+
+    /// <summary>
+    /// Turns off Warning log when no handler is found for event. Turned on by default.
+    /// </summary>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public EventBrokerBuilder DisableMissingHandlerWarningLog()
+    {
+        _disableMissingHandlerWarningLog = true;
+        return this;
+    }
+}

--- a/src/M.EventBrokerSlim/Internal/EventHandlerDescriptor.cs
+++ b/src/M.EventBrokerSlim/Internal/EventHandlerDescriptor.cs
@@ -5,6 +5,7 @@ namespace M.EventBrokerSlim.Internal;
 
 internal sealed record EventHandlerDescriptor(
     string Key,
+    Type EventType,
     Type InterfaceType,
     Func<object, object, Task> Handle,
     Func<object, object, Exception, Task> OnError);

--- a/src/M.EventBrokerSlim/Internal/EventHandlerRegistry.cs
+++ b/src/M.EventBrokerSlim/Internal/EventHandlerRegistry.cs
@@ -6,24 +6,8 @@ namespace M.EventBrokerSlim.Internal;
 internal sealed class EventHandlerRegistry
 {
     private readonly Dictionary<Type, List<EventHandlerDescriptor>> _eventHandlerDescriptors = new();
-    private int _maxConcurrentHandlers = 2;
 
-    internal int MaxConcurrentHandlers
-    {
-        get
-        {
-            return _maxConcurrentHandlers;
-        }
-        set
-        {
-            if (value <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), "MaxConcurrentHandlers should be greater than zero");
-            }
-
-            _maxConcurrentHandlers = value;
-        }
-    }
+    internal int MaxConcurrentHandlers { get; set; } = 2;
 
     internal bool DisableMissingHandlerWarningLog { get; set; }
 
@@ -33,20 +17,14 @@ internal sealed class EventHandlerRegistry
         return handlers;
     }
 
-    internal void RegisterHandlerDescriptor<TEvent, THandler>(string eventHandlerKey) where THandler : class, IEventHandler<TEvent>
+    internal void AddHandlerDescriptor(EventHandlerDescriptor eventHandlerDescriptor)
     {
-        var descriptor = new EventHandlerDescriptor(
-                    Key: eventHandlerKey,
-                    InterfaceType: typeof(IEventHandler<TEvent>),
-                    Handle: async (handler, @event) => await ((THandler)handler).Handle((TEvent)@event),
-                    OnError: async (handler, @event, exception) => await ((THandler)handler).OnError(exception, (TEvent)@event));
-
-        if (!_eventHandlerDescriptors.TryGetValue(typeof(TEvent), out var handlers))
+        if (!_eventHandlerDescriptors.TryGetValue(eventHandlerDescriptor.EventType, out var handlers))
         {
             handlers = new List<EventHandlerDescriptor>();
-            _eventHandlerDescriptors.Add(typeof(TEvent), handlers);
+            _eventHandlerDescriptors.Add(eventHandlerDescriptor.EventType, handlers);
         }
 
-        handlers.Add(descriptor);
+        handlers.Add(eventHandlerDescriptor);
     }
 }

--- a/test/M.EventBrokerSlim.Tests/EventBrokerTests.cs
+++ b/test/M.EventBrokerSlim.Tests/EventBrokerTests.cs
@@ -80,7 +80,7 @@ public class EventBrokerTests
     {
         // Arrange
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddEventBroker(_ => { });
+        serviceCollection.AddEventBroker();
 
         var channelKey = serviceCollection.Single(x => x.IsKeyedService && x.ServiceType == typeof(Channel<object>)).ServiceKey;
 

--- a/test/M.EventBrokerSlim.Tests/HandlerExecutionTests.cs
+++ b/test/M.EventBrokerSlim.Tests/HandlerExecutionTests.cs
@@ -17,8 +17,8 @@ public class HandlerExecutionTests
         // Arrange
         var services = ServiceProviderHelper.BuildWithEventsRecorder<int>(
             sc => sc.AddEventBroker(
-                        x => x.AddKeyedTransient<TestEvent, TestEventHandler>()
-                              .WithMaxConcurrentHandlers(1)));
+                        x => x.WithMaxConcurrentHandlers(1)
+                              .AddKeyedTransient<TestEvent, TestEventHandler>()));
 
         using var scope = services.CreateScope();
 
@@ -49,8 +49,8 @@ public class HandlerExecutionTests
         // Arrange
         var services = ServiceProviderHelper.BuildWithEventsRecorder<int>(
             sc => sc.AddEventBroker(
-                        x => x.AddKeyedTransient<TestEvent, TestEventHandler>()
-                              .WithMaxConcurrentHandlers(2)));
+                        x => x.WithMaxConcurrentHandlers(2)
+                              .AddKeyedTransient<TestEvent, TestEventHandler>()));
 
         using var scope = services.CreateScope();
 
@@ -80,7 +80,7 @@ public class HandlerExecutionTests
     {
         // Arrange
         var services = ServiceProviderHelper.BuildWithEventsRecorder<int>(
-            sc => sc.AddEventBroker(_ => { }));
+            sc => sc.AddEventBroker());
 
         using var scope = services.CreateScope();
 
@@ -104,7 +104,7 @@ public class HandlerExecutionTests
     {
         // Arrange
         var services = ServiceProviderHelper.BuildWithEventsRecorderAndLogger<int>(
-            sc => sc.AddEventBroker(_ => { }));
+            sc => sc.AddEventBroker());
 
         using var scope = services.CreateScope();
 

--- a/test/M.EventBrokerSlim.Tests/HandlerScopeAndInstanceTests.cs
+++ b/test/M.EventBrokerSlim.Tests/HandlerScopeAndInstanceTests.cs
@@ -14,8 +14,8 @@ public class HandlerScopeAndInstanceTests
         // Arrange
         var services = ServiceProviderHelper.BuildWithEventsRecorder<int>(
             sc => sc.AddEventBroker(
-                        x => x.AddKeyedTransient<TestEvent, TestEventHandler>()
-                              .WithMaxConcurrentHandlers(1)));
+                        x => x.WithMaxConcurrentHandlers(1)
+                              .AddKeyedTransient<TestEvent, TestEventHandler>()));
 
         using var scope = services.CreateScope();
 
@@ -48,8 +48,8 @@ public class HandlerScopeAndInstanceTests
         // Arrange
         var services = ServiceProviderHelper.BuildWithEventsRecorder<int>(
             sc => sc.AddEventBroker(
-                        x => x.AddKeyedSingleton<TestEvent, TestEventHandler>()
-                              .WithMaxConcurrentHandlers(1)));
+                        x => x.WithMaxConcurrentHandlers(1)
+                              .AddKeyedSingleton<TestEvent, TestEventHandler>()));
 
         using var scope = services.CreateScope();
 
@@ -82,8 +82,8 @@ public class HandlerScopeAndInstanceTests
         // Arrange
         var services = ServiceProviderHelper.BuildWithEventsRecorder<int>(
             sc => sc.AddEventBroker(
-                        x => x.AddKeyedScoped<TestEvent, TestEventHandler>()
-                              .WithMaxConcurrentHandlers(1)));
+                        x => x.WithMaxConcurrentHandlers(1)
+                              .AddKeyedScoped<TestEvent, TestEventHandler>()));
 
         using var scope = services.CreateScope();
 


### PR DESCRIPTION
Introduce `IServiceCollection.AddEventHandlers` extension method so that `EventBroker` and event handlers can be registered separately.