### PR TITLE
Cancel deferred and pending tasks on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ public class SomeEventHandler : IEventHandler<SomeEvent>
     {
     }
 
-    public async Task Handle(SomeEvent @event)
+    public async Task Handle(SomeEvent @event, CancellationToken cancellationToken)
     {
         // process the event
     }
 
-    public async Task OnError(Exception exception, SomeEvent @event)
+    public async Task OnError(Exception exception, SomeEvent @event, CancellationToken cancellationToken)
     {
         // called on unhandled exeption from Handle 
     }

--- a/package-readme.md
+++ b/package-readme.md
@@ -23,12 +23,12 @@ public class SomeEventHandler : IEventHandler<SomeEvent>
     {
     }
 
-    public async Task Handle(SomeEvent @event)
+    public async Task Handle(SomeEvent @event, CancellationToken cancellationToken)
     {
         // process the event
     }
 
-    public Task OnError(Exception exception, SomeEvent @event)
+    public Task OnError(Exception exception, SomeEvent @event, CancellationToken cancellationToken)
     {
         // called on unhandled exeption from Handle 
     }

--- a/src/M.EventBrokerSlim/DependencyInjection/EventHandlerRegistryBuilder.cs
+++ b/src/M.EventBrokerSlim/DependencyInjection/EventHandlerRegistryBuilder.cs
@@ -73,8 +73,8 @@ public class EventHandlerRegistryBuilder
             Key: eventHandlerKey,
             EventType: typeof(TEvent),
             InterfaceType: typeof(IEventHandler<TEvent>),
-            Handle: async (handler, @event) => await ((THandler)handler).Handle((TEvent)@event),
-            OnError: async (handler, @event, exception) => await ((THandler)handler).OnError(exception, (TEvent)@event));
+            Handle: async (handler, @event, ct) => await ((THandler)handler).Handle((TEvent)@event, ct),
+            OnError: async (handler, @event, exception, ct) => await ((THandler)handler).OnError(exception, (TEvent)@event, ct));
 
         _eventsHandlersDescriptors.Add(descriptor);
     }

--- a/src/M.EventBrokerSlim/IEventHandler.cs
+++ b/src/M.EventBrokerSlim/IEventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -15,7 +16,8 @@ public interface IEventHandler<TEvent>
     /// Handles the event.
     /// </summary>
     /// <param name="event">An instance of <typeparamref name="TEvent"/> representing the event.</param>
-    Task Handle(TEvent @event);
+    /// <param name="cancellationToken">A cancellation token that should be used to cancel the work</param>
+    Task Handle(TEvent @event, CancellationToken cancellationToken);
 
     /// <summary>
     /// Called when an unhadled exception is caught during execution.
@@ -24,5 +26,6 @@ public interface IEventHandler<TEvent>
     /// </summary>
     /// <param name="exception">The exception caught.</param>
     /// <param name="event">The event instance which handling caused the exception.</param>
-    Task OnError(Exception exception, TEvent @event);
+    /// <param name="cancellationToken">A cancellation token that should be used to cancel the work</param>
+    Task OnError(Exception exception, TEvent @event, CancellationToken cancellationToken);
 }

--- a/src/M.EventBrokerSlim/Internal/EventHandlerDescriptor.cs
+++ b/src/M.EventBrokerSlim/Internal/EventHandlerDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace M.EventBrokerSlim.Internal;
@@ -7,5 +8,5 @@ internal sealed record EventHandlerDescriptor(
     Guid Key,
     Type EventType,
     Type InterfaceType,
-    Func<object, object, Task> Handle,
-    Func<object, object, Exception, Task> OnError);
+    Func<object, object, CancellationToken, Task> Handle,
+    Func<object, object, Exception, CancellationToken, Task> OnError);

--- a/test/M.EventBrokerSlim.Tests/EventRecorder.cs
+++ b/test/M.EventBrokerSlim.Tests/EventRecorder.cs
@@ -18,6 +18,8 @@ public class EventsRecorder<T>
 
     public T[] HandledEventIds => _events.OrderBy(x => x.tick).Select(x => x.id).ToArray();
 
+    public T[] Expected => _expected.Keys.ToArray();
+
     public int[] HandlerObjectsHashCodes => _handlerInstances.OrderBy(x => x.tick).Select(x => x.id).ToArray();
 
     public int[] HandlerScopeHashCodes => _scopeInstances.OrderBy(x => x.tick).Select(x => x.id).ToArray();

--- a/test/M.EventBrokerSlim.Tests/ExceptionHandlingTests.cs
+++ b/test/M.EventBrokerSlim.Tests/ExceptionHandlingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using M.EventBrokerSlim.DependencyInjection;
 using MELT;
@@ -154,7 +155,7 @@ public class ExceptionHandlingTests
             _eventsRecorder = eventBroker;
         }
 
-        public Task Handle(TestEvent @event)
+        public Task Handle(TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecorder.Notify(@event);
             if (@event.ThrowFromHandle)
@@ -165,7 +166,7 @@ public class ExceptionHandlingTests
             return Task.CompletedTask;
         }
 
-        public Task OnError(Exception exception, TestEvent @event)
+        public Task OnError(Exception exception, TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecorder.Notify(exception, @event);
             if (@event.ThrowFromOnError)
@@ -185,8 +186,8 @@ public class ExceptionHandlingTests
             _input = input;
         }
 
-        public Task Handle(TestEvent @event) => throw new NotImplementedException();
+        public Task Handle(TestEvent @event, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task OnError(Exception exception, TestEvent @event) => throw new NotImplementedException();
+        public Task OnError(Exception exception, TestEvent @event, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 }

--- a/test/M.EventBrokerSlim.Tests/HandlerExecutionTests.cs
+++ b/test/M.EventBrokerSlim.Tests/HandlerExecutionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using M.EventBrokerSlim.DependencyInjection;
 using MELT;
@@ -162,7 +163,7 @@ public class HandlerExecutionTests
             _eventsRecoder = eventsRecorder;
         }
 
-        public async Task Handle(TestEvent @event)
+        public async Task Handle(TestEvent @event, CancellationToken cancellationToken)
         {
             if (@event.TimeToRun != default)
             {
@@ -172,7 +173,7 @@ public class HandlerExecutionTests
             _eventsRecoder.Notify(@event);
         }
 
-        public Task OnError(Exception exception, TestEvent @event)
+        public Task OnError(Exception exception, TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecoder.Notify(exception, @event);
             return Task.CompletedTask;

--- a/test/M.EventBrokerSlim.Tests/HandlerRegistrationTests.cs
+++ b/test/M.EventBrokerSlim.Tests/HandlerRegistrationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using M.EventBrokerSlim.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
@@ -199,21 +200,19 @@ public class HandlerRegistrationTests
     public class TestEventHandler : IEventHandler<TestEvent>
     {
         private readonly EventsRecorder<string> _eventsRecorder;
-        private readonly IServiceProvider _scope;
 
-        public TestEventHandler(EventsRecorder<string> eventsRecorder, IServiceProvider scope)
+        public TestEventHandler(EventsRecorder<string> eventsRecorder)
         {
             _eventsRecorder = eventsRecorder;
-            _scope = scope;
         }
 
-        public Task Handle(TestEvent @event)
+        public Task Handle(TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecorder.Notify($"{@event.CorrelationId}_{GetType().Name}");
             return Task.CompletedTask;
         }
 
-        public Task OnError(Exception exception, TestEvent @event)
+        public Task OnError(Exception exception, TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecorder.Notify(exception, @event);
             return Task.CompletedTask;
@@ -222,14 +221,14 @@ public class HandlerRegistrationTests
 
     public class TestEventHandler1 : TestEventHandler
     {
-        public TestEventHandler1(EventsRecorder<string> eventsRecorder, IServiceProvider scope) : base(eventsRecorder, scope)
+        public TestEventHandler1(EventsRecorder<string> eventsRecorder) : base(eventsRecorder)
         {
         }
     }
 
     public class TestEventHandler2 : TestEventHandler
     {
-        public TestEventHandler2(EventsRecorder<string> eventsRecorder, IServiceProvider scope) : base(eventsRecorder, scope)
+        public TestEventHandler2(EventsRecorder<string> eventsRecorder) : base(eventsRecorder)
         {
         }
     }

--- a/test/M.EventBrokerSlim.Tests/HandlerScopeAndInstanceTests.cs
+++ b/test/M.EventBrokerSlim.Tests/HandlerScopeAndInstanceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using M.EventBrokerSlim.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
@@ -123,14 +124,14 @@ public class HandlerScopeAndInstanceTests
             _scope = scope;
         }
 
-        public Task Handle(TestEvent @event)
+        public Task Handle(TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecorder.Notify(@event);
             _eventsRecorder.Notify(@event, handlerInstance: GetHashCode(), scopeInstance: _scope.GetHashCode());
             return Task.CompletedTask;
         }
 
-        public Task OnError(Exception exception, TestEvent @event)
+        public Task OnError(Exception exception, TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecorder.Notify(exception, @event);
             return Task.CompletedTask;

--- a/test/M.EventBrokerSlim.Tests/MultipleHandlersTests.cs
+++ b/test/M.EventBrokerSlim.Tests/MultipleHandlersTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using M.EventBrokerSlim.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,13 +55,13 @@ public class MultipleHandlersTests
             _eventsRecorder = eventsRecorder;
         }
 
-        public Task Handle(TestEvent @event)
+        public Task Handle(TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecorder.Notify($"{@event.CorrelationId}_{GetType().Name}");
             return Task.CompletedTask;
         }
 
-        public Task OnError(Exception exception, TestEvent @event)
+        public Task OnError(Exception exception, TestEvent @event, CancellationToken cancellationToken)
         {
             _eventsRecorder.Notify(exception, @event);
             return Task.CompletedTask;


### PR DESCRIPTION
Cancel all pending events handling and propagate cancellation to all currently executing handlers on `IEventBroker.Shoudown()`